### PR TITLE
chore: add file download bullet to template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,7 +10,7 @@ _<sub>If not applicable remove.</sub>_
 _(Notes on how the proposed changes could be tested)_
 
 ## Manual test covered
-_<sub>If not relevant _(eg chore PR)_ do omit this section. Alternatively leave only what is relevant.</sub>_
+_<sub>If not relevant (eg chore PR) do omit this section. Alternatively leave only what is relevant.</sub>_
 
 - [ ] Linking
   - [ ] Links overview contains correct information

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,7 +10,7 @@ _<sub>If not applicable remove.</sub>_
 _(Notes on how the proposed changes could be tested)_
 
 ## Manual test covered
-_<sub>If not relevant (eg chore PR) do omit this section. Alternatively leave only what is relevant.</sub>_
+_<sub>If not relevant _(eg chore PR)_ do omit this section. Alternatively leave only what is relevant.</sub>_
 
 - [ ] Linking
   - [ ] Links overview contains correct information
@@ -24,6 +24,7 @@ _<sub>If not relevant (eg chore PR) do omit this section. Alternatively leave on
     - [ ] Overlay icon
     - [ ] Resource shows relevant data
   - [ ] RTF
+- [ ] File Download
 - [ ] Sync trigger from doppel
 - [ ] Regrssion
 - [ ] Logs checked for potential errors


### PR DESCRIPTION
# Integration Pull Request

## Description

Added an additional bullet for the Pull Request Template, for the download of the file in the testing section.

## How to test

Open a PR for any organisation repository, that does not have its own template defined. The PR description should be filled with the template content.

## References

Issue: https://github.com/chaseappio/ruta-40/issues/5481